### PR TITLE
library release: nrf_modem v1.5.1

### DIFF
--- a/nrf_802154/CMakeLists.txt
+++ b/nrf_802154/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, Nordic Semiconductor ASA
+# Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/CMakeLists.txt
+++ b/nrf_802154/driver/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, Nordic Semiconductor ASA
+# Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/include/nrf_802154.h
+++ b/nrf_802154/driver/include/nrf_802154.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/include/nrf_802154_config.h
+++ b/nrf_802154/driver/include/nrf_802154_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/include/nrf_802154_const.h
+++ b/nrf_802154/driver/include/nrf_802154_const.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/include/nrf_802154_types.h
+++ b/nrf_802154/driver/include/nrf_802154_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/include/platform/nrf_802154_random.h
+++ b/nrf_802154/driver/include/platform/nrf_802154_random.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/fal/nrf_802154_fal.c
+++ b/nrf_802154/driver/src/fal/nrf_802154_fal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/fal/nrf_802154_fal.h
+++ b/nrf_802154/driver/src/fal/nrf_802154_fal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_ack_data.c
+++ b/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_ack_data.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_ack_data.h
+++ b/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_ack_data.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_ack_generator.c
+++ b/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_ack_generator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_ack_generator.h
+++ b/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_ack_generator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_enh_ack_generator.c
+++ b/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_enh_ack_generator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_enh_ack_generator.h
+++ b/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_enh_ack_generator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_imm_ack_generator.c
+++ b/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_imm_ack_generator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_imm_ack_generator.h
+++ b/nrf_802154/driver/src/mac_features/ack_generator/nrf_802154_imm_ack_generator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_ack_timeout.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_ack_timeout.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_ack_timeout.h
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_ack_timeout.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_csma_ca.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_csma_ca.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_csma_ca.h
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_csma_ca.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_delayed_trx.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_delayed_trx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -921,7 +921,7 @@ bool nrf_802154_delayed_trx_nearest_drx_time_to_midpoint_get(uint32_t * p_drx_ti
 {
     bool     result            = false;
     uint32_t min_time_to_start = 0xffffffff;
-    uint32_t drx_time_to_start;
+    uint32_t drx_time_to_start = 0;
     uint32_t drx_time_to_midpoint;
 
     for (int i = 0; i < sizeof(m_dly_rx_data) / sizeof(m_dly_rx_data[0]); i++)

--- a/nrf_802154/driver/src/mac_features/nrf_802154_delayed_trx.h
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_delayed_trx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_filter.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_filter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_filter.h
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_filter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_frame_parser.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_frame_parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_frame_parser.h
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_frame_parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_ie_writer.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_ie_writer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_ie_writer.h
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_ie_writer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_ifs.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_ifs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_ifs.h
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_ifs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_precise_ack_timeout.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_precise_ack_timeout.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_security_pib.h
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_security_pib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_security_pib_ram.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_security_pib_ram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_security_writer.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_security_writer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/mac_features/nrf_802154_security_writer.h
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_security_writer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154.c
+++ b/nrf_802154/driver/src/nrf_802154.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_aes_ccm.c
+++ b/nrf_802154/driver/src/nrf_802154_aes_ccm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_aes_ccm.h
+++ b/nrf_802154/driver/src/nrf_802154_aes_ccm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_core.c
+++ b/nrf_802154/driver/src/nrf_802154_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_core.h
+++ b/nrf_802154/driver/src/nrf_802154_core.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_core_hooks.c
+++ b/nrf_802154/driver/src/nrf_802154_core_hooks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_core_hooks.h
+++ b/nrf_802154/driver/src/nrf_802154_core_hooks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_critical_section.c
+++ b/nrf_802154/driver/src/nrf_802154_critical_section.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_critical_section.h
+++ b/nrf_802154/driver/src/nrf_802154_critical_section.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_debug.c
+++ b/nrf_802154/driver/src/nrf_802154_debug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_debug.h
+++ b/nrf_802154/driver/src/nrf_802154_debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_debug_assert.c
+++ b/nrf_802154/driver/src/nrf_802154_debug_assert.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_debug_core.h
+++ b/nrf_802154/driver/src/nrf_802154_debug_core.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_debug_gpio.c
+++ b/nrf_802154/driver/src/nrf_802154_debug_gpio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_debug_log.h
+++ b/nrf_802154/driver/src/nrf_802154_debug_log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_debug_log_codes.h
+++ b/nrf_802154/driver/src/nrf_802154_debug_log_codes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_encrypt.c
+++ b/nrf_802154/driver/src/nrf_802154_encrypt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_encrypt.h
+++ b/nrf_802154/driver/src/nrf_802154_encrypt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_notification.h
+++ b/nrf_802154/driver/src/nrf_802154_notification.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_notification_direct.c
+++ b/nrf_802154/driver/src/nrf_802154_notification_direct.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_notification_swi.c
+++ b/nrf_802154/driver/src/nrf_802154_notification_swi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_nrfx_addons.h
+++ b/nrf_802154/driver/src/nrf_802154_nrfx_addons.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_peripherals.h
+++ b/nrf_802154/driver/src/nrf_802154_peripherals.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_peripherals_alloc.c
+++ b/nrf_802154/driver/src/nrf_802154_peripherals_alloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_peripherals_nrf52.h
+++ b/nrf_802154/driver/src/nrf_802154_peripherals_nrf52.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_peripherals_nrf53.h
+++ b/nrf_802154/driver/src/nrf_802154_peripherals_nrf53.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_pib.c
+++ b/nrf_802154/driver/src/nrf_802154_pib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_pib.h
+++ b/nrf_802154/driver/src/nrf_802154_pib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_priority_drop_swi.c
+++ b/nrf_802154/driver/src/nrf_802154_priority_drop_swi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_procedures_duration.h
+++ b/nrf_802154/driver/src/nrf_802154_procedures_duration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_queue.c
+++ b/nrf_802154/driver/src/nrf_802154_queue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_queue.h
+++ b/nrf_802154/driver/src/nrf_802154_queue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_request.h
+++ b/nrf_802154/driver/src/nrf_802154_request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_request_direct.c
+++ b/nrf_802154/driver/src/nrf_802154_request_direct.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_request_swi.c
+++ b/nrf_802154/driver/src/nrf_802154_request_swi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_rssi.c
+++ b/nrf_802154/driver/src/nrf_802154_rssi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_rssi.h
+++ b/nrf_802154/driver/src/nrf_802154_rssi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_rx_buffer.c
+++ b/nrf_802154/driver/src/nrf_802154_rx_buffer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_rx_buffer.h
+++ b/nrf_802154/driver/src/nrf_802154_rx_buffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_stats.c
+++ b/nrf_802154/driver/src/nrf_802154_stats.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_stats.h
+++ b/nrf_802154/driver/src/nrf_802154_stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_swi.c
+++ b/nrf_802154/driver/src/nrf_802154_swi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_swi.h
+++ b/nrf_802154/driver/src/nrf_802154_swi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_trx.c
+++ b/nrf_802154/driver/src/nrf_802154_trx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_trx.h
+++ b/nrf_802154/driver/src/nrf_802154_trx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_trx_dppi.c
+++ b/nrf_802154/driver/src/nrf_802154_trx_dppi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_trx_ppi.c
+++ b/nrf_802154/driver/src/nrf_802154_trx_ppi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_trx_ppi_api.h
+++ b/nrf_802154/driver/src/nrf_802154_trx_ppi_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_tx_work_buffer.c
+++ b/nrf_802154/driver/src/nrf_802154_tx_work_buffer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_tx_work_buffer.h
+++ b/nrf_802154/driver/src/nrf_802154_tx_work_buffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_utils.h
+++ b/nrf_802154/driver/src/nrf_802154_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/nrf_802154_utils_byteorder.h
+++ b/nrf_802154/driver/src/nrf_802154_utils_byteorder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/platform/random/nrf_802154_random_newlib.c
+++ b/nrf_802154/driver/src/platform/random/nrf_802154_random_newlib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/driver/src/platform/random/nrf_802154_random_stdlib.c
+++ b/nrf_802154/driver/src/platform/random/nrf_802154_random_stdlib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/CMakeLists.txt
+++ b/nrf_802154/serialization/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, Nordic Semiconductor ASA
+# Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/host/nrf_802154.h
+++ b/nrf_802154/serialization/include/host/nrf_802154.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -255,6 +255,21 @@ void nrf_802154_init(void);
  * @retval  false  The driver could not schedule changing state.
  */
 bool nrf_802154_sleep(void);
+
+/**
+ * @brief Changes the radio state to the @ref RADIO_STATE_SLEEP state if the radio is idle.
+ *
+ * The sleep state is the lowest power state. In this state, the radio cannot transmit or receive
+ * frames. It is the only state in which the driver releases the high-frequency clock and does not
+ * request timeslots from a radio arbiter.
+ *
+ * @note If another module requests it, the high-frequency clock may be enabled even in the radio
+ *       sleep state.
+ *
+ * @retval  NRF_802154_SLEEP_ERROR_NONE  The radio changes its state to the low power mode.
+ * @retval  NRF_802154_SLEEP_ERROR_BUSY  The driver could not schedule changing state.
+ */
+nrf_802154_sleep_error_t nrf_802154_sleep_if_idle(void);
 
 /**
  * @brief Changes the radio state to @ref RADIO_STATE_RX.

--- a/nrf_802154/serialization/include/host/nrf_802154_callouts.h
+++ b/nrf_802154/serialization/include/host/nrf_802154_callouts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/host/nrf_802154_config.h
+++ b/nrf_802154/serialization/include/host/nrf_802154_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/host/nrf_802154_const.h
+++ b/nrf_802154/serialization/include/host/nrf_802154_const.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/host/nrf_802154_types.h
+++ b/nrf_802154/serialization/include/host/nrf_802154_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -82,6 +82,14 @@ typedef uint8_t nrf_802154_rx_error_t;
 typedef uint8_t nrf_802154_ed_error_t;
 
 #define NRF_802154_ED_ERROR_ABORTED 0x01 // !< Procedure was aborted by another operation.
+
+/**
+ * @brief Possible errors during sleep procedure call.
+ */
+typedef uint8_t nrf_802154_sleep_error_t;
+
+#define NRF_802154_SLEEP_ERROR_NONE 0x00 // !< There is no error.
+#define NRF_802154_SLEEP_ERROR_BUSY 0x01 // !< The driver cannot enter the sleep state due to the ongoing operation.
 
 /**
  * @brief Possible errors during the CCA procedure.

--- a/nrf_802154/serialization/include/platform/nrf_802154_serialization_crit_sect.h
+++ b/nrf_802154/serialization/include/platform/nrf_802154_serialization_crit_sect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/platform/nrf_802154_spinel_backend.h
+++ b/nrf_802154/serialization/include/platform/nrf_802154_spinel_backend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/platform/nrf_802154_spinel_backend_callouts.h
+++ b/nrf_802154/serialization/include/platform/nrf_802154_spinel_backend_callouts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/platform/nrf_802154_spinel_log.h
+++ b/nrf_802154/serialization/include/platform/nrf_802154_spinel_log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/platform/nrf_802154_spinel_response_notifier.h
+++ b/nrf_802154/serialization/include/platform/nrf_802154_spinel_response_notifier.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/serialization/nrf_802154_serialization.h
+++ b/nrf_802154/serialization/include/serialization/nrf_802154_serialization.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/serialization/nrf_802154_serialization_config.h
+++ b/nrf_802154/serialization/include/serialization/nrf_802154_serialization_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/include/serialization/nrf_802154_serialization_error.h
+++ b/nrf_802154/serialization/include/serialization/nrf_802154_serialization_error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_buffer_allocator.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_buffer_allocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_buffer_mgr_dst.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_buffer_mgr_dst.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_buffer_mgr_src.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_buffer_mgr_src.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_kvmap.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_kvmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_serialization_error_helper.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_serialization_error_helper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_spinel.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_spinel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_spinel_datatypes.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_spinel_datatypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -387,6 +387,12 @@ typedef enum
     SPINEL_PROP_VENDOR_NORDIC_NRF_802154_MODULATED_CARRIER =
         SPINEL_PROP_VENDOR_NORDIC_NRF_802154__BEGIN + 53,
 
+    /**
+     * Vendor property for nrf_802154_sleep_if_idle serialization.
+     */
+    SPINEL_PROP_VENDOR_NORDIC_NRF_802154_SLEEP_IF_IDLE =
+        SPINEL_PROP_VENDOR_NORDIC_NRF_802154__BEGIN + 54,
+
 } spinel_prop_vendor_key_t;
 
 /**
@@ -636,27 +642,37 @@ typedef enum
 /**
  * @brief Spinel data type description for SPINEL_PROP_LAST_STATUS.
  */
-#define SPINEL_DATATYPE_SPINEL_PROP_LAST_STATUS SPINEL_DATATYPE_UINT_PACKED_S
+#define SPINEL_DATATYPE_SPINEL_PROP_LAST_STATUS      SPINEL_DATATYPE_UINT_PACKED_S
 
 /**
  * @brief Spinel data type description for nrf_802154_sleep.
  */
-#define SPINEL_DATATYPE_NRF_802154_SLEEP        SPINEL_DATATYPE_NULL_S
+#define SPINEL_DATATYPE_NRF_802154_SLEEP             SPINEL_DATATYPE_NULL_S
 
 /**
  * @brief Spinel data type description for nrf_802154_sleep result.
  */
-#define SPINEL_DATATYPE_NRF_802154_SLEEP_RET    SPINEL_DATATYPE_BOOL_S
+#define SPINEL_DATATYPE_NRF_802154_SLEEP_RET         SPINEL_DATATYPE_BOOL_S
+
+/**
+ * @brief Spinel data type description for nrf_802154_sleep_if_idle.
+ */
+#define SPINEL_DATATYPE_NRF_802154_SLEEP_IF_IDLE     SPINEL_DATATYPE_NULL_S
+
+/**
+ * @brief Spinel data type description for nrf_802154_sleep_if_idle result.
+ */
+#define SPINEL_DATATYPE_NRF_802154_SLEEP_IF_IDLE_RET SPINEL_DATATYPE_UINT8_S
 
 /**
  * @brief Spinel data type description for nrf_802154_receive.
  */
-#define SPINEL_DATATYPE_NRF_802154_RECEIVE      SPINEL_DATATYPE_NULL_S
+#define SPINEL_DATATYPE_NRF_802154_RECEIVE           SPINEL_DATATYPE_NULL_S
 
 /**
  * @brief Spinel data type description for nrf_802154_receive result.
  */
-#define SPINEL_DATATYPE_NRF_802154_RECEIVE_RET  SPINEL_DATATYPE_BOOL_S
+#define SPINEL_DATATYPE_NRF_802154_RECEIVE_RET       SPINEL_DATATYPE_BOOL_S
 
 /**
  * @brief Spinel data type description for nrf_802154_receive_at.

--- a/nrf_802154/serialization/src/include/nrf_802154_spinel_dec.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_spinel_dec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_spinel_dec_app.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_spinel_dec_app.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_spinel_dec_net.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_spinel_dec_net.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_spinel_enc.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_spinel_enc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_spinel_enc_app.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_spinel_enc_app.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/include/nrf_802154_spinel_enc_net.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_spinel_enc_net.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/nrf_802154_buffer_allocator.c
+++ b/nrf_802154/serialization/src/nrf_802154_buffer_allocator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/nrf_802154_buffer_mgr_dst.c
+++ b/nrf_802154/serialization/src/nrf_802154_buffer_mgr_dst.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/nrf_802154_buffer_mgr_src.c
+++ b/nrf_802154/serialization/src/nrf_802154_buffer_mgr_src.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/nrf_802154_kvmap.c
+++ b/nrf_802154/serialization/src/nrf_802154_kvmap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/nrf_802154_spinel.c
+++ b/nrf_802154/serialization/src/nrf_802154_spinel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/nrf_802154_spinel_app.c
+++ b/nrf_802154/serialization/src/nrf_802154_spinel_app.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -392,6 +392,36 @@ bool nrf_802154_sleep(void)
 
     res = net_generic_bool_response_await(CONFIG_NRF_802154_SER_DEFAULT_RESPONSE_TIMEOUT,
                                           &sleep_remote_resp);
+
+    SERIALIZATION_ERROR_CHECK(res, error, bail);
+
+bail:
+    SERIALIZATION_ERROR_RAISE_IF_FAILED(error);
+
+    return sleep_remote_resp;
+}
+
+nrf_802154_sleep_error_t nrf_802154_sleep_if_idle(void)
+{
+    nrf_802154_ser_err_t     res;
+    nrf_802154_sleep_error_t sleep_remote_resp = NRF_802154_SLEEP_ERROR_NONE;
+
+    SERIALIZATION_ERROR_INIT(error);
+
+    NRF_802154_SPINEL_LOG_BANNER_CALLING();
+
+    nrf_802154_spinel_response_notifier_lock_before_request(
+        SPINEL_PROP_VENDOR_NORDIC_NRF_802154_SLEEP_IF_IDLE);
+
+    res = nrf_802154_spinel_send_cmd_prop_value_set(
+        SPINEL_PROP_VENDOR_NORDIC_NRF_802154_SLEEP_IF_IDLE,
+        SPINEL_DATATYPE_NRF_802154_SLEEP_IF_IDLE,
+        NULL);
+
+    SERIALIZATION_ERROR_CHECK(res, error, bail);
+
+    res = net_generic_uint8_response_await(CONFIG_NRF_802154_SER_DEFAULT_RESPONSE_TIMEOUT,
+                                           &sleep_remote_resp);
 
     SERIALIZATION_ERROR_CHECK(res, error, bail);
 

--- a/nrf_802154/serialization/src/nrf_802154_spinel_dec.c
+++ b/nrf_802154/serialization/src/nrf_802154_spinel_dec.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/serialization/src/nrf_802154_spinel_dec_app.c
+++ b/nrf_802154/serialization/src/nrf_802154_spinel_dec_app.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -565,6 +565,8 @@ nrf_802154_ser_err_t nrf_802154_spinel_decode_cmd_prop_value_is(
         case SPINEL_PROP_LAST_STATUS:
         // fall through
         case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_SLEEP:
+        // fall through
+        case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_SLEEP_IF_IDLE:
         // fall through
         case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_RECEIVE:
         // fall through

--- a/nrf_802154/serialization/src/nrf_802154_spinel_dec_net.c
+++ b/nrf_802154/serialization/src/nrf_802154_spinel_dec_net.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -72,6 +72,28 @@ static nrf_802154_ser_err_t spinel_decode_prop_nrf_802154_sleep(const void * p_p
     return nrf_802154_spinel_send_cmd_prop_value_is(SPINEL_PROP_VENDOR_NORDIC_NRF_802154_SLEEP,
                                                     SPINEL_DATATYPE_NRF_802154_SLEEP_RET,
                                                     sleep_response);
+}
+
+/**
+ * @brief Deal with SPINEL_PROP_VENDOR_NORDIC_NRF_802154_SLEEP_IF_IDLE request and send response.
+ *
+ * @param[in]  p_property_data    Pointer to a buffer - unused here (no additional data to decode).
+ * @param[in]  property_data_len  Size of the @ref p_data buffer - unused here.
+ *
+ */
+static nrf_802154_ser_err_t spinel_decode_prop_nrf_802154_sleep_if_idle(
+    const void * p_property_data,
+    size_t       property_data_len)
+{
+    (void)p_property_data;
+    (void)property_data_len;
+
+    nrf_802154_sleep_error_t sleep_response = nrf_802154_sleep_if_idle();
+
+    return nrf_802154_spinel_send_cmd_prop_value_is(
+        SPINEL_PROP_VENDOR_NORDIC_NRF_802154_SLEEP_IF_IDLE,
+        SPINEL_DATATYPE_NRF_802154_SLEEP_IF_IDLE_RET,
+        sleep_response);
 }
 
 /**
@@ -1528,6 +1550,9 @@ nrf_802154_ser_err_t nrf_802154_spinel_decode_cmd_prop_value_set(const void * p_
     {
         case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_SLEEP:
             return spinel_decode_prop_nrf_802154_sleep(p_property_data, property_data_len);
+
+        case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_SLEEP_IF_IDLE:
+            return spinel_decode_prop_nrf_802154_sleep_if_idle(p_property_data, property_data_len);
 
         case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_RECEIVE:
             return spinel_decode_prop_nrf_802154_receive(p_property_data, property_data_len);

--- a/nrf_802154/serialization/src/nrf_802154_spinel_net.c
+++ b/nrf_802154/serialization/src/nrf_802154_spinel_net.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/CMakeLists.txt
+++ b/nrf_802154/sl/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+# Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_ant_div.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_ant_div.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_capabilities.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_capabilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_coex.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_coex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_config.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_crit_sect_if.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_crit_sect_if.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_fault.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_fault.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_log.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_periphs.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_periphs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_rsch.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_rsch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_stats.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_timer.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_types.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/nrf_802154_sl_utils.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/platform/nrf_802154_clock.h
+++ b/nrf_802154/sl/include/platform/nrf_802154_clock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/platform/nrf_802154_gpiote.h
+++ b/nrf_802154/sl/include/platform/nrf_802154_gpiote.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/platform/nrf_802154_hp_timer.h
+++ b/nrf_802154/sl/include/platform/nrf_802154_hp_timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/platform/nrf_802154_irq.h
+++ b/nrf_802154/sl/include/platform/nrf_802154_irq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/platform/nrf_802154_lp_timer.h
+++ b/nrf_802154/sl/include/platform/nrf_802154_lp_timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/platform/nrf_802154_temperature.h
+++ b/nrf_802154/sl/include/platform/nrf_802154_temperature.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/rsch/nrf_802154_rsch.h
+++ b/nrf_802154/sl/include/rsch/nrf_802154_rsch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/rsch/nrf_802154_rsch_crit_sect.h
+++ b/nrf_802154/sl/include/rsch/nrf_802154_rsch_crit_sect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/rsch/nrf_802154_rsch_prio_drop.h
+++ b/nrf_802154/sl/include/rsch/nrf_802154_rsch_prio_drop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/timer/nrf_802154_timer_coord.h
+++ b/nrf_802154/sl/include/timer/nrf_802154_timer_coord.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/include/timer/nrf_802154_timer_sched.h
+++ b/nrf_802154/sl/include/timer/nrf_802154_timer_sched.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/platform/clock/nrf_802154_clock.c
+++ b/nrf_802154/sl/platform/clock/nrf_802154_clock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/nrf_802154/sl/platform/clock/nrf_802154_clock_mpsl.c
+++ b/nrf_802154/sl/platform/clock/nrf_802154_clock_mpsl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/nrf_802154/sl/platform/gpiote/nrf_802154_gpiote_crit_sect.c
+++ b/nrf_802154/sl/platform/gpiote/nrf_802154_gpiote_crit_sect.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/nrf_802154/sl/platform/gpiote/nrf_802154_gpiote_none.c
+++ b/nrf_802154/sl/platform/gpiote/nrf_802154_gpiote_none.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/nrf_802154/sl/platform/hp_timer/nrf_802154_hp_timer.c
+++ b/nrf_802154/sl/platform/hp_timer/nrf_802154_hp_timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/nrf_802154/sl/platform/irq/nrf_802154_irq_baremetal.c
+++ b/nrf_802154/sl/platform/irq/nrf_802154_irq_baremetal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/nrf_802154/sl/platform/lp_timer/nrf_802154_lp_timer.c
+++ b/nrf_802154/sl/platform/lp_timer/nrf_802154_lp_timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/nrf_802154/sl/platform/lp_timer/nrf_802154_lp_timer_none.c
+++ b/nrf_802154/sl/platform/lp_timer/nrf_802154_lp_timer_none.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/nrf_802154/sl/platform/temperature/nrf_802154_temperature_none.c
+++ b/nrf_802154/sl/platform/temperature/nrf_802154_temperature_none.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/nrf_802154/sl/sl/CMakeLists.txt
+++ b/nrf_802154/sl/sl/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Nordic Semiconductor ASA
+# Copyright (c) 2021 - 2022 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #

--- a/nrf_802154/sl/sl_opensource/CMakeLists.txt
+++ b/nrf_802154/sl/sl_opensource/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, Nordic Semiconductor ASA
+# Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_ant_div.c
+++ b/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_ant_div.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_capabilities.c
+++ b/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_capabilities.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2021 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_coex.c
+++ b/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_coex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_crit_sect_if.c
+++ b/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_crit_sect_if.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_fem.c
+++ b/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_fem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_log.c
+++ b/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_rsch.c
+++ b/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_rsch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_timer.c
+++ b/nrf_802154/sl/sl_opensource/src/nrf_802154_sl_timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2021, Nordic Semiconductor ASA
+ * Copyright (c) 2020 - 2022, Nordic Semiconductor ASA
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/nrf_802154/zephyr/Kconfig.nrfxlib
+++ b/nrf_802154/zephyr/Kconfig.nrfxlib
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 - 2021 Nordic Semiconductor ASA
+# Copyright (c) 2020 - 2022 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #

--- a/nrf_modem/doc/CHANGELOG.rst
+++ b/nrf_modem/doc/CHANGELOG.rst
@@ -9,6 +9,26 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
+nrf_modem 1.5.0
+***************
+
+* tmp restructure
+* project: automated_release: Group config
+* project: automated_release: start of automated release process
+* ztest: Fix failure output of ztest build script
+* rpc: trace: Add support for deferred trace processing
+* tests: interfaces: mfu: spelling error in comments
+* interface: mfu: Rename mfu2 to mfu
+* interface: mfu: Removal of DFU socket
+* ztest: correct test_group filter
+* ci: Adding build system test stage
+* CODEOWNERS Remove @even from CODEOWNERS
+* test: ztest: at: replace sleeps with semaphores
+* manifest: update manifest for v1.4.1 release
+* include: nrf_modem_gnss: fix incorrect use of doxygen tag
+* version: update VERSION to 1.4.1
+* interface: ip: fix handling of RPC_IP_ERR_WOULDBLOCK in send()
+
 nrf_modem 1.4.1
 ***************
 

--- a/nrf_modem/include/nrf_modem.h
+++ b/nrf_modem/include/nrf_modem.h
@@ -171,8 +171,26 @@ void nrf_modem_application_irq_handler(void);
  * @brief Trace IRQ handler in the modem library.
  *
  * Call this function when handling the Trace IRQ.
+ *
  */
 void nrf_modem_trace_irq_handler(void);
+
+/**
+ * @brief Function to indicate that the application has completed the processing of a trace buffer
+ *
+ * The application shall call this function to let the modem library free the trace memory
+ * pointed to by @p buf. It is the application's responsibility to call this function with
+ * the same parameter values as received in the @ref nrf_modem_os_trace_put function.
+ * Calling this function with incorrect values leads to undefined behavior.
+ *
+ * @param buf Pointer to the memory buffer as received in @ref nrf_modem_os_trace_put
+ * @param len Length of memory buffer as received in @ref nrf_modem_os_trace_put
+ * @retval Zero on success.
+ * @retval -NRF_EINVAL @p buf is @c NULL or an invalid trace buffer
+ * @retval -NRF_EINVAL @p len is too large to be a valid trace length
+ * @retval -NRF_EAGAIN Resource temporarily unavailable. Try again with same parameters.
+ */
+int nrf_modem_trace_processed_callback(const uint8_t *buf, uint32_t len);
 
 #ifdef __cplusplus
 }

--- a/nrf_modem/include/nrf_modem_os.h
+++ b/nrf_modem/include/nrf_modem_os.h
@@ -166,7 +166,13 @@ void nrf_modem_os_trace_irq_set(void);
 void nrf_modem_os_trace_irq_clear(void);
 
 /**
- * @brief Output Trace data from the trace buffer.
+ * @brief Receive trace data from the modem.
+ *
+ * The modem library calls this function to forward trace data to the application.
+ *
+ * The memory pointed to by @p data is not freed until
+ * @ref nrf_modem_trace_processed_callback is called.
+ * The application may thus defer the processing trace data as necessary.
  *
  * @param data Memory buffer containing the output trace data.
  * @param len  Memory buffer length.

--- a/nrf_modem/include/nrf_modem_platform.h
+++ b/nrf_modem/include/nrf_modem_platform.h
@@ -25,26 +25,6 @@ extern "C" {
 #define NRF_MODEM_SHMEM_CTRL_SIZE 0x4e8
 /**@} */
 
-/**@defgroup nrf_modem_reserved_interrupts Reserved Interrupt and Priorities
- * @{
- * @brief  Interrupts and priorities reserved by the library for communication with the
- *         application and the network layer.
- */
-
-/**@brief Interrupt used for communication with the network layer. */
-#define NRF_MODEM_NETWORK_IRQ IPC_IRQn
-
-/**@brief Interrupt priority used on interrupt for communication with the network layer. */
-#define NRF_MODEM_NETWORK_IRQ_PRIORITY 0
-
-/**@brief Interrupt used for communication with the application layer. */
-#define NRF_MODEM_APPLICATION_IRQ EGU1_IRQn
-
-/**@brief Interrupt priority used on interrupt for communication with the application layer. */
-#define NRF_MODEM_APPLICATION_IRQ_PRIORITY 6
-
-/**@} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/nrf_modem/include/nrf_socket.h
+++ b/nrf_modem/include/nrf_socket.h
@@ -75,10 +75,6 @@ typedef int32_t ssize_t;
  */
 /** Unspecified address family */
 #define NRF_AF_UNSPEC 0
-/** Family to identify protocols/operations local to Nordic device.
- *  @deprecated since v1.3.0.
- */
-#define NRF_AF_LOCAL 1
 /** IPv4 socket family. */
 #define NRF_AF_INET 2
 /** Raw packet family. */
@@ -127,10 +123,6 @@ typedef int32_t ssize_t;
  *  @deprecated since v1.3.0.
  */
 #define NRF_PROTO_AT 513
-/** DFU protocol.
- *  @deprecated since v1.3.0.
- */
-#define NRF_PROTO_DFU 515
 /**@} */
 
 /**
@@ -227,83 +219,6 @@ typedef uint32_t nrf_fd_set;
 #define NRF_SO_SEC_SESSION_CACHE_PURGE 9
 /**@} */
 
-/**@defgroup nrf_socket_dfu DFU socket
- * @brief DFU socket API
- * @deprecated since v1.3.0.
- * @{
- */
-/**@brief
- * Socket option to read the modem firmware version (UUID).
- * @sa nrf_dfu_fw_version_t.
- *
- * @deprecated since v1.3.0.
- */
-#define NRF_SO_DFU_FW_VERSION 1
-
-/**@brief
- * Socket option to retrieve the size of the largest firmware image
- * that can be transferred to the modem for firmware updates.
- * @sa nrf_dfu_resources_t.
- *
- * @deprecated since v1.3.0.
- */
-#define NRF_SO_DFU_RESOURCES 2
-
-/**@brief
- * Socket option to control the timeout to send a firmware fragment.
- * @note Not implemented.
- *
- * @deprecated since v1.3.0.
- */
-#define NRF_SO_DFU_TIMEO 3
-
-/**@brief
- * Socket option to schedule a modem firmware update at next boot.
- * The result of the update is returned by nrf_modem_init, at next boot.
- * The modem needs to be reset once more to run the updated firmware.
- *
- * @deprecated since v1.3.0.
- */
-#define NRF_SO_DFU_APPLY 4
-
-/**@brief
- * Socket option to schedule a rollback of a firmware update at next boot.
- *
- * @deprecated since v1.3.0.
- */
-#define NRF_SO_DFU_REVERT 5
-
-/**@brief
- * Socket option to delete a modem firmware image from the modem's scratch area.
- * This option removes the possibility to rollback to a previous version,
- * and is necessary to receive new firmware images.
- *
- * @deprecated since v1.3.0.
- */
-#define NRF_SO_DFU_BACKUP_DELETE 6
-
-/**@brief
- * Socket option read and write the offset of the downloaded firmware image
- * in the modem's scratch area. This option is used to determine whether
- * a firmware image exists in the modem's scratch area and its size.
- * A value of 2.5 megabytes (2621440 bytes) is returned if the scratch area
- * is dirty, and needs erasing (via NRF_SO_DFU_BACKUP_DELETE).
- * If non-zero and different from 2.5 megabytes, the value indicates the size
- * of the firmware image received so far.
- *
- * @deprecated since v1.3.0.
- */
-#define NRF_SO_DFU_OFFSET 7
-
-/**@brief
- * Socket option to retrieve the latest DFU error, see @ref nrf_dfu_errors.
- * Read-only.
- * @deprecated since v1.3.0.
- */
-#define NRF_SO_DFU_ERROR 20
-
-/** @} */
-
 /**@defgroup nrf_socket_options_sockets Generic socket options
  * @brief Socket options used with both AT and IP sockets
  * @ingroup nrf_socket
@@ -355,8 +270,6 @@ typedef uint32_t nrf_fd_set;
  */
 #define NRF_SOL_SOCKET 1
 #define NRF_SOL_SECURE 282
-/** @deprecated since v1.3.0. */
-#define NRF_SOL_DFU    515
 /**@} */
 
 /**@defgroup nrf_socket_send_recv_flags Socket send/recv flags.
@@ -656,65 +569,6 @@ struct nrf_ifreq {
 	char ifr_name[NRF_IFNAMSIZ]; /* Interface name */
 };
 /**@} */
-
-/**@addtogroup nrf_socket_dfu
- * @{
- */
-
-/**@brief
- * Universally unique identifier of the modem firmware version.
- * The UUID format is defined by RFC 4122.
- * @deprecated since v1.3.0.
- */
-typedef uint8_t nrf_dfu_fw_version_t[36];
-
-/**@brief
- * Maximum size for a firmware image, in bytes.
- * @deprecated since v1.3.0.
- */
-typedef uint32_t nrf_dfu_resources_t;
-
-/**@brief
- * Size of the firmware image stored in flash, in bytes.
- * @deprecated since v1.3.0.
- */
-typedef uint32_t nrf_dfu_fw_offset_t;
-
-/**@defgroup nrf_dfu_errors DFU errors
- * @brief    DFU socket errors.
- * @deprecated since v1.3.0.
- * @{
- */
-
-/**@brief DFU socket error.
- * @deprecated since v1.3.0.
- */
-typedef int32_t nrf_dfu_err_t;
-
-#define DFU_NO_ERROR		     0
-#define DFU_RECEIVER_OUT_OF_MEMORY   -1
-#define DFU_RECEIVER_BLOCK_TOO_LARGE -2
-#define DFU_INVALID_HEADER_DATA	     -3
-#define DFU_ERROR_INTERNAL_00	     -4
-#define DFU_INVALID_DATA	     -5
-#define DFU_ERROR_INTERNAL_01	     -6
-#define DFU_ERROR_INTERNAL_02	     -7
-#define DFU_ERROR_INTERNAL_03	     -8
-#define DFU_INVALID_UUID	     -9
-#define DFU_INVALID_ADDRESS	     -10
-#define DFU_AREA_NOT_BLANK	     -11
-#define DFU_WRITE_ERROR		     -12
-#define DFU_ERASE_ERROR		     -13
-#define DFU_INVALID_FILE_OFFSET	     -14
-#define DFU_PROGRESS_LOG_INVALID     -15
-#define DFU_INVALID_RESUME_ATTEMPT   -16
-#define DFU_ERASE_PENDING	     -17
-#define DFU_OPERATION_NOT_ALLOWED    -18
-#define DFU_INCOMPLETE_DATA	     -19
-#define DFU_INTERRUPTED_WRITE	     -20
-
-/** @} */
-/** @} */
 
 /**@defgroup nrf_socket_api nRF Socket interface
  * @{


### PR DESCRIPTION
library release: nrf_modem v1.5.1
nrf_modem: version 1.5.1

* interface: mfu: Rename mfu2 to mfu
* interface: mfu: Removal of DFU socket 

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>
Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>
